### PR TITLE
refactor: consolidate DB path resolution into config module

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {
@@ -43,6 +43,14 @@ impl Config {
         }
 
         config
+    }
+
+    pub fn db_dir(&self, root: &str) -> PathBuf {
+        Path::new(root).join(&self.db_path)
+    }
+
+    pub fn vector_dir(&self, root: &str) -> PathBuf {
+        self.db_dir(root).join("vector")
     }
 }
 

--- a/src/core/generator.rs
+++ b/src/core/generator.rs
@@ -1,3 +1,4 @@
+use crate::core::config::Config;
 use crate::core::embedding::EmbeddingEngine;
 use crate::core::graph::DependencyGraph;
 use crate::core::symbol::SymbolRef;
@@ -14,7 +15,9 @@ pub struct ContextGenerator;
 
 impl ContextGenerator {
     pub async fn generate(focus_query: Option<String>, depth: u8) -> Result<()> {
-        let db_dir = Path::new(".database");
+        let config = Config::load(".");
+        let db_dir = config.db_dir(".");
+        let vector_path = config.vector_dir(".");
         let output_dir = Path::new(".amdb");
 
         if !output_dir.exists() {
@@ -29,7 +32,7 @@ impl ContextGenerator {
             std::process::exit(1);
         }
 
-        let db = ContextDb::open(db_dir)?;
+        let db = ContextDb::open(&db_dir)?;
         let all_edges = db.get_all_relationships()?;
         let all_files = db.get_all_files()?;
 
@@ -77,9 +80,15 @@ impl ContextGenerator {
             );
 
             let embedder = EmbeddingEngine::new()?;
-            let paths =
-                Self::resolve_focus_targets(db_dir, &all_files, &db, query, &embedder, &graph)
-                    .await?;
+            let paths = Self::resolve_focus_targets(
+                &vector_path,
+                &all_files,
+                &db,
+                query,
+                &embedder,
+                &graph,
+            )
+            .await?;
 
             if paths.is_empty() {
                 println!(
@@ -138,7 +147,7 @@ impl ContextGenerator {
     }
 
     async fn resolve_focus_targets(
-        db_dir: &Path,
+        vector_path: &Path,
         all_files: &[String],
         db: &ContextDb,
         query: &str,
@@ -166,8 +175,7 @@ impl ContextGenerator {
         }
 
         if paths.is_empty() {
-            let vector_path = db_dir.join("vector");
-            let store = VectorStore::open(&vector_path)?;
+            let store = VectorStore::open(vector_path)?;
             let query_vec = embedder.embed(query)?;
             let results = store.search(&query_vec, 10, Some(graph))?;
 

--- a/src/core/indexer.rs
+++ b/src/core/indexer.rs
@@ -35,8 +35,8 @@ pub struct IndexWorker {
 impl IndexWorker {
     pub fn new(root: &str) -> Result<Self> {
         let config = Config::load(root);
-        let db_dir = Path::new(root).join(&config.db_path);
-        let vector_path = db_dir.join("vector");
+        let db_dir = config.db_dir(root);
+        let vector_path = config.vector_dir(root);
 
         let db = ContextDb::open(&db_dir)?;
         if db.needs_reindex {
@@ -131,8 +131,8 @@ impl IndexWorker {
 impl Indexer {
     pub fn scan_project(root: &str) -> Result<()> {
         let config = Config::load(root);
-        let db_dir = Path::new(root).join(&config.db_path);
-        let vector_path = db_dir.join("vector");
+        let db_dir = config.db_dir(root);
+        let vector_path = config.vector_dir(root);
 
         fs::create_dir_all(&vector_path)?;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -764,6 +764,42 @@ fn test_callee_file_persisted_for_unique_symbol() -> Result<(), Box<dyn std::err
 }
 
 #[test]
+fn test_all_subcommands_agree_on_custom_db_path() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let root = temp_dir.path();
+
+    fs::write(root.join("amdb.toml"), "db_path = \".custom_shared_db\"\n")?;
+    fs::write(
+        root.join("shared_path_check.rs"),
+        "fn shared_path_unique_fn() {}",
+    )?;
+
+    cargo_bin_cmd!("amdb")
+        .current_dir(root)
+        .arg("init")
+        .arg(".")
+        .assert()
+        .success();
+
+    assert!(root.join(".custom_shared_db/context.db").exists());
+    assert!(root.join(".custom_shared_db/vector/vectors.db").exists());
+    assert!(!root.join(".database").exists());
+
+    cargo_bin_cmd!("amdb")
+        .current_dir(root)
+        .arg("generate")
+        .assert()
+        .success();
+
+    assert!(!root.join(".database").exists());
+
+    let content = fs::read_to_string(root.join(".amdb/context.md"))?;
+    assert!(content.contains("shared_path_unique_fn"));
+
+    Ok(())
+}
+
+#[test]
 fn test_ambiguous_callee_marked_unresolved_or_split() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
     let root = temp_dir.path();


### PR DESCRIPTION
## Summary
- Make `core::config` the single source of truth for the database directory: new `Config::db_dir(root)` and `Config::vector_dir(root)` accessors (vector path derived from the db dir, not independently).
- Fix the real divergence: `generator.rs` hardcoded `.database`, so `generate` with a custom `db_path` in `amdb.toml` failed against a database `init` had just written. It now loads `Config` like the other subcommands.
- `indexer.rs` (`IndexWorker::new` and `Indexer::scan_project`) uses the accessors instead of duplicated inline joins; the daemon watcher inherits this via `IndexWorker::new`.
- Precedence unchanged: `AMDB_DB_PATH` env var > `amdb.toml` > default `.database`. No `serve` subcommand added.

## Tests
- New `test_all_subcommands_agree_on_custom_db_path`: sets a custom `db_path`, runs `init` then `generate`, asserts both DB files exist under the custom path and `.database` is never created.
- All 25 existing tests remain green (26 total); `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` clean.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)