### PR TITLE
feat: expose amdb as an MCP server over stdio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .amdb/*
 !.amdb/config.toml
 **/.DS_Store
-.vscode
+.vscode/*
+!.vscode/mcp.json
 .idea
 *.swp
 .amdb/

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "amdb": {
+      "command": "amdb",
+      "args": ["serve"]
+    }
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,8 +73,11 @@ dependencies = [
  "predicates",
  "rayon",
  "regex",
+ "rmcp",
  "rusqlite",
+ "schemars",
  "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "toml",
@@ -96,6 +99,15 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -202,6 +214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,7 +249,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror",
  "v_frame",
@@ -386,6 +409,18 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -566,8 +601,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -585,12 +630,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -619,7 +688,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",
@@ -682,6 +751,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -901,31 +976,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "futures"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -934,22 +1036,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -957,7 +1060,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1215,6 +1317,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2032,6 +2158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2344,6 +2476,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2585,40 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "pastey 0.2.3",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -2528,6 +2714,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,10 +2799,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.149"
+name = "serde_derive_internals"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3593,6 +3816,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amdb"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ ordered-float = "4.0"
 toml = "0.8"
 bincode = "1.3"
 crossbeam-channel = "0.5"
+rmcp = { version = "2.2.0", default-features = false, features = ["server", "macros", "transport-io", "schemars"] }
+schemars = "1.2.1"
+serde_json = "1.0.150"
 
 [profile.release]
 lto = "thin"
@@ -60,4 +63,5 @@ lto = "thin"
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "3.0"
+serde_json = "1.0.150"
 tempfile = "3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amdb"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Turn your codebase into AI context. A high-performance context generator for LLMs (Cursor, Claude) using Tree-sitter and Vector Search."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -135,6 +135,43 @@ The daemon will:
 
 ---
 
+## 🔌 MCP Server: Plug amdb into Your AI Tools
+
+`amdb serve` exposes the local index as a [Model Context Protocol](https://modelcontextprotocol.io) server over **stdio** — no HTTP, no remote hosting, your code never leaves the machine. Any MCP-capable client (VSCode, Cursor, Claude Code, Zed) can query the index directly.
+
+Run `amdb init` first, then register the server with your client.
+
+**VSCode / Cursor** — add `.vscode/mcp.json` to your project:
+
+```json
+{
+  "servers": {
+    "amdb": {
+      "command": "amdb",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+**Claude Code**:
+
+```bash
+claude mcp add amdb -- amdb serve
+```
+
+The server exposes three tools, all reading from the pre-built local index:
+
+| Tool | What it returns |
+| :- | :- |
+| `amdb_get_context` | Full project overview: files, symbols, and the mermaid dependency graph |
+| `amdb_focus` | Context narrowed to a query via name match + semantic vector search, expanded by `depth` dependency hops |
+| `amdb_get_symbol` | Every definition of a symbol name as JSON: file, kind, line, signature, callers, and callees (with resolver-accurate files) |
+
+If no index exists the tools respond with an error asking you to run `amdb init` — the server never indexes on its own.
+
+---
+
 ## 🛠 Supported Languages
 
 `amdb` uses robust Tree-sitter parsers to fully understand the syntax and structure of:

--- a/src/core/generator.rs
+++ b/src/core/generator.rs
@@ -3,7 +3,7 @@ use crate::core::embedding::EmbeddingEngine;
 use crate::core::graph::DependencyGraph;
 use crate::core::symbol::SymbolRef;
 use crate::core::vector_store::VectorStore;
-use crate::db::ContextDb;
+use crate::db::{ContextDb, Relationship};
 use anyhow::Result;
 use console::style;
 use std::collections::{HashMap, HashSet};
@@ -12,6 +12,13 @@ use std::io::Write;
 use std::path::Path;
 
 pub struct ContextGenerator;
+
+pub struct GraphData {
+    pub all_edges: Vec<Relationship>,
+    pub all_files: Vec<String>,
+    pub graph: DependencyGraph,
+    pub symbol_to_files: HashMap<String, Vec<String>>,
+}
 
 impl ContextGenerator {
     pub async fn generate(focus_query: Option<String>, depth: u8) -> Result<()> {
@@ -29,6 +36,66 @@ impl ContextGenerator {
         }
 
         let db = ContextDb::open(&db_dir)?;
+        let data = Self::load_graph_data(&db)?;
+
+        let target_files: Vec<String>;
+        let output_filename: String;
+
+        if let Some(query) = &focus_query {
+            output_filename = Self::focus_filename(query);
+
+            println!(
+                "{}",
+                style(format!(
+                    "Filtering context for: '{}' with depth {}...",
+                    query, depth
+                ))
+                .cyan()
+            );
+
+            match Self::compute_focus_files(&db, &vector_path, &data, query, depth, 10)? {
+                Some(files) => target_files = files,
+                None => {
+                    println!(
+                        "{}",
+                        style("No matches found. Falling back to full context.").yellow()
+                    );
+                    target_files = data.all_files.clone();
+                }
+            }
+        } else {
+            output_filename = "context.md".to_string();
+            println!("{}", style("Generating full project context...").blue());
+            target_files = data.all_files.clone();
+        }
+
+        let content = Self::render_report(
+            &db,
+            &data,
+            &target_files,
+            focus_query.as_deref(),
+            &output_filename,
+        )?;
+
+        let output_path = output_dir.join(&output_filename);
+        let mut file = File::create(&output_path)?;
+        file.write_all(content.as_bytes())?;
+
+        println!(
+            "{}",
+            style(format!("Generated: {}", output_path.display()))
+                .green()
+                .bold()
+        );
+        Ok(())
+    }
+
+    pub fn focus_filename(query: &str) -> String {
+        let safe_name = query.replace(" ", "-").replace("/", "-").to_lowercase();
+        format!("{}.md", safe_name)
+    }
+
+    pub fn load_graph_data(db: &ContextDb) -> Result<GraphData> {
         let all_edges = db.get_all_relationships()?;
         let all_files = db.get_all_files()?;
 
@@ -59,96 +126,87 @@ impl ContextGenerator {
             }
         }
 
-        let target_files: Vec<String>;
-        let output_filename: String;
+        Ok(GraphData {
+            all_edges,
+            all_files,
+            graph,
+            symbol_to_files,
+        })
+    }
 
-        if let Some(query) = &focus_query {
-            let safe_name = query.replace(" ", "-").replace("/", "-").to_lowercase();
-            output_filename = format!("{}.md", safe_name);
+    pub fn compute_focus_files(
+        db: &ContextDb,
+        vector_path: &Path,
+        data: &GraphData,
+        query: &str,
+        depth: u8,
+        limit: usize,
+    ) -> Result<Option<Vec<String>>> {
+        let embedder = EmbeddingEngine::new()?;
+        let paths = Self::resolve_focus_targets(
+            vector_path,
+            &data.all_files,
+            db,
+            query,
+            &embedder,
+            &data.graph,
+            limit,
+        )?;
 
-            println!(
-                "{}",
-                style(format!(
-                    "Filtering context for: '{}' with depth {}...",
-                    query, depth
-                ))
-                .cyan()
-            );
-
-            let embedder = EmbeddingEngine::new()?;
-            let paths = Self::resolve_focus_targets(
-                &vector_path,
-                &all_files,
-                &db,
-                query,
-                &embedder,
-                &graph,
-            )
-            .await?;
-
-            if paths.is_empty() {
-                println!(
-                    "{}",
-                    style("No matches found. Falling back to full context.").yellow()
-                );
-                target_files = all_files;
-            } else {
-                let mut file_graph: HashMap<String, HashSet<String>> = HashMap::new();
-                for edge in &all_edges {
-                    let caller_file = &edge.caller.file;
-                    if let Some(callee_files) = symbol_to_files.get(&edge.callee) {
-                        for callee_file in callee_files {
-                            if caller_file != callee_file {
-                                file_graph
-                                    .entry(caller_file.clone())
-                                    .or_default()
-                                    .insert(callee_file.clone());
-                            }
-                        }
-                    }
-                }
-                target_files = Self::expand_graph_depth(paths, &file_graph, depth);
-            }
-        } else {
-            output_filename = "context.md".to_string();
-            println!("{}", style("Generating full project context...").blue());
-            target_files = all_files;
+        if paths.is_empty() {
+            return Ok(None);
         }
 
-        let mapped_edges: Vec<(&SymbolRef, &str, Option<&str>)> = all_edges
+        let mut file_graph: HashMap<String, HashSet<String>> = HashMap::new();
+        for edge in &data.all_edges {
+            let caller_file = &edge.caller.file;
+            if let Some(callee_files) = data.symbol_to_files.get(&edge.callee) {
+                for callee_file in callee_files {
+                    if caller_file != callee_file {
+                        file_graph
+                            .entry(caller_file.clone())
+                            .or_default()
+                            .insert(callee_file.clone());
+                    }
+                }
+            }
+        }
+
+        Ok(Some(Self::expand_graph_depth(paths, &file_graph, depth)))
+    }
+
+    pub fn render_report(
+        db: &ContextDb,
+        data: &GraphData,
+        target_files: &[String],
+        focus_query: Option<&str>,
+        output_filename: &str,
+    ) -> Result<String> {
+        let mapped_edges: Vec<(&SymbolRef, &str, Option<&str>)> = data
+            .all_edges
             .iter()
             .map(|e| (&e.caller, e.callee.as_str(), e.callee_file.as_deref()))
             .collect();
 
-        let content = Self::format_markdown_report(
-            &db,
-            &target_files,
+        Self::format_markdown_report(
+            db,
+            target_files,
             &mapped_edges,
-            &symbol_to_files,
-            focus_query.as_deref(),
-            &output_filename,
-        )?;
-
-        let output_path = output_dir.join(&output_filename);
-        let mut file = File::create(&output_path)?;
-        file.write_all(content.as_bytes())?;
-
-        println!(
-            "{}",
-            style(format!("Generated: {}", output_path.display()))
-                .green()
-                .bold()
-        );
-        Ok(())
+            &data.symbol_to_files,
+            focus_query,
+            output_filename,
+        )
     }
 
-    async fn resolve_focus_targets(
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_focus_targets(
         vector_path: &Path,
         all_files: &[String],
         db: &ContextDb,
         query: &str,
         embedder: &EmbeddingEngine,
         graph: &DependencyGraph,
+        limit: usize,
     ) -> Result<Vec<String>> {
         let mut paths = Vec::new();
 
@@ -173,7 +231,7 @@ impl ContextGenerator {
         if paths.is_empty() {
             let store = VectorStore::open(vector_path)?;
             let query_vec = embedder.embed(query)?;
-            let results = store.search(&query_vec, 10, Some(graph))?;
+            let results = store.search(&query_vec, limit, Some(graph))?;
 
             if !results.is_empty() {
                 let best_dist = results[0].0;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,3 @@
 pub mod query;
 pub mod schema;
-pub use query::ContextDb;
+pub use query::{ContextDb, Relationship};

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -198,6 +198,68 @@ impl ContextDb {
         Ok(warnings)
     }
 
+    pub fn get_symbols_by_name(&self, name: &str) -> Result<Vec<(String, CodeSymbol)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT file_path, name, kind, line, docstring, is_public, signature FROM symbols WHERE name = ?1 ORDER BY file_path, line",
+        )?;
+        let rows = stmt.query_map(params![name], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                CodeSymbol {
+                    name: row.get(1)?,
+                    kind: row.get(2)?,
+                    line: row.get(3)?,
+                    docstring: row.get(4)?,
+                    is_public: row.get::<_, i64>(5).unwrap_or(1) != 0,
+                    signature: row.get(6)?,
+                },
+            ))
+        })?;
+
+        let mut symbols = Vec::new();
+        for sym in rows {
+            symbols.push(sym?);
+        }
+        Ok(symbols)
+    }
+
+    pub fn get_callers_of(&self, callee: &str, callee_file: &str) -> Result<Vec<SymbolRef>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT DISTINCT file_path, caller FROM relationships WHERE callee = ?1 AND (callee_file = ?2 OR callee_file IS NULL) ORDER BY file_path, caller",
+        )?;
+        let rows = stmt.query_map(params![callee, callee_file], |row| {
+            Ok(SymbolRef::new(
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+            ))
+        })?;
+
+        let mut callers = Vec::new();
+        for caller in rows {
+            callers.push(caller?);
+        }
+        Ok(callers)
+    }
+
+    pub fn get_callees_of(
+        &self,
+        file: &str,
+        caller: &str,
+    ) -> Result<Vec<(String, Option<String>)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT DISTINCT callee, callee_file FROM relationships WHERE file_path = ?1 AND caller = ?2 ORDER BY callee",
+        )?;
+        let rows = stmt.query_map(params![file, caller], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })?;
+
+        let mut callees = Vec::new();
+        for callee in rows {
+            callees.push(callee?);
+        }
+        Ok(callees)
+    }
+
     pub fn get_all_files(&self) -> Result<Vec<String>> {
         let mut stmt = self
             .conn

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::FmtSubscriber;
 mod core;
 mod daemon;
 mod db;
+mod mcp;
 
 use crate::core::generator::ContextGenerator;
 use crate::core::indexer::Indexer;
@@ -39,6 +40,7 @@ enum Commands {
         #[arg(short, long, default_value_t = 1)]
         depth: u8,
     },
+    Serve,
 }
 
 #[tokio::main]
@@ -51,13 +53,24 @@ async fn main() -> anyhow::Result<()> {
         Level::INFO
     };
 
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(log_level)
-        .with_target(false)
-        .without_time()
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+    if matches!(cli.command, Commands::Serve) {
+        let subscriber = FmtSubscriber::builder()
+            .with_max_level(log_level)
+            .with_target(false)
+            .without_time()
+            .with_writer(std::io::stderr)
+            .finish();
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("setting default subscriber failed");
+    } else {
+        let subscriber = FmtSubscriber::builder()
+            .with_max_level(log_level)
+            .with_target(false)
+            .without_time()
+            .finish();
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("setting default subscriber failed");
+    }
 
     let result = match cli.command {
         Commands::Init { path } => {
@@ -73,6 +86,10 @@ async fn main() -> anyhow::Result<()> {
         Commands::Generate { focus, depth } => ContextGenerator::generate(focus, depth)
             .await
             .context("Generation error"),
+        Commands::Serve => {
+            info!("Starting amdb MCP server on stdio");
+            mcp::serve_stdio().await.context("Serve error")
+        }
     };
 
     if let Err(e) = result {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,242 @@
+use crate::core::config::Config;
+use crate::core::generator::ContextGenerator;
+use crate::db::ContextDb;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, ContentBlock, ErrorData};
+use rmcp::{tool, tool_handler, tool_router, ServerHandler, ServiceExt};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::json;
+use std::path::PathBuf;
+
+#[derive(Deserialize, JsonSchema)]
+pub struct GetContextParams {
+    #[schemars(
+        description = "Accepted for parity with `amdb generate`; the full-project overview does not vary with depth. Default 1."
+    )]
+    pub depth: Option<u8>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct FocusParams {
+    #[schemars(
+        description = "What to focus on: a symbol name, a file name, or a natural-language description of a feature or concept."
+    )]
+    pub query: String,
+    #[schemars(
+        description = "How many dependency-graph hops around the matched files to include. Default 1."
+    )]
+    pub depth: Option<u8>,
+    #[schemars(
+        description = "Maximum number of semantic vector-search matches to consider when no exact name match exists. Default 10."
+    )]
+    pub limit: Option<u32>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct GetSymbolParams {
+    #[schemars(description = "Exact symbol name to look up (case-sensitive).")]
+    pub name: String,
+    #[schemars(
+        description = "Optional file path (relative to the project root, as shown by amdb_get_context) to restrict the lookup to when the name is defined in several files."
+    )]
+    pub file: Option<String>,
+}
+
+pub struct AmdbServer;
+
+struct Index {
+    db: ContextDb,
+    vector_path: PathBuf,
+    warning: Option<String>,
+}
+
+fn internal(e: anyhow::Error) -> ErrorData {
+    ErrorData::internal_error(format!("{:#}", e), None)
+}
+
+impl AmdbServer {
+    fn open_index(&self) -> Result<Index, CallToolResult> {
+        let config = Config::load(".");
+        let db_dir = config.db_dir(".");
+
+        if !db_dir.join("context.db").exists() {
+            return Err(CallToolResult::error(vec![ContentBlock::text(format!(
+                "No amdb index found at {}. Run `amdb init` in the project root first, then retry.",
+                db_dir.display()
+            ))]));
+        }
+
+        let db = ContextDb::open(&db_dir).map_err(|e| {
+            CallToolResult::error(vec![ContentBlock::text(format!(
+                "Failed to open the amdb index at {}: {}. Run `amdb init` to rebuild it.",
+                db_dir.display(),
+                e
+            ))])
+        })?;
+
+        let warning = db.needs_reindex.then(|| {
+            "WARNING: the index uses a legacy schema and may be stale. Run `amdb init` to rebuild it before relying on these results.".to_string()
+        });
+
+        Ok(Index {
+            db,
+            vector_path: config.vector_dir("."),
+            warning,
+        })
+    }
+
+    fn ok_with_warning(warning: Option<String>, payload: String) -> CallToolResult {
+        let mut content = Vec::new();
+        if let Some(w) = warning {
+            content.push(ContentBlock::text(w));
+        }
+        content.push(ContentBlock::text(payload));
+        CallToolResult::success(content)
+    }
+}
+
+#[tool_router]
+impl AmdbServer {
+    #[tool(
+        description = "Return a full overview of the indexed project: every file with its symbols (name, kind, signature) plus the cross-file dependency graph in mermaid form. Use this first to orient yourself in the codebase before drilling into specific files. Results come from the pre-built local amdb index created by `amdb init`; they reflect the last index run, not the live file system."
+    )]
+    async fn amdb_get_context(
+        &self,
+        params: Parameters<GetContextParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let _ = params.0.depth;
+        let index = match self.open_index() {
+            Ok(i) => i,
+            Err(e) => return Ok(e),
+        };
+
+        let data = ContextGenerator::load_graph_data(&index.db).map_err(internal)?;
+        let report =
+            ContextGenerator::render_report(&index.db, &data, &data.all_files, None, "context.md")
+                .map_err(internal)?;
+
+        Ok(Self::ok_with_warning(index.warning, report))
+    }
+
+    #[tool(
+        description = "Return project context narrowed to a query: files whose name or symbols match it exactly, or, failing that, the semantically closest files found by local vector search with dependency-graph boosting, expanded by `depth` dependency hops. Use this when you need context about one feature, file, or concept instead of the whole project. Results come from the pre-built local amdb index and its embeddings; run `amdb init` to refresh them."
+    )]
+    async fn amdb_focus(
+        &self,
+        params: Parameters<FocusParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let p = params.0;
+        let index = match self.open_index() {
+            Ok(i) => i,
+            Err(e) => return Ok(e),
+        };
+
+        let depth = p.depth.unwrap_or(1);
+        let limit = p.limit.unwrap_or(10) as usize;
+
+        let data = ContextGenerator::load_graph_data(&index.db).map_err(internal)?;
+        let targets = ContextGenerator::compute_focus_files(
+            &index.db,
+            &index.vector_path,
+            &data,
+            &p.query,
+            depth,
+            limit,
+        )
+        .map_err(internal)?;
+
+        match targets {
+            None => Ok(Self::ok_with_warning(
+                index.warning,
+                format!(
+                    "No files in the index matched '{}' by name, symbol, or semantic similarity.",
+                    p.query
+                ),
+            )),
+            Some(files) => {
+                let filename = ContextGenerator::focus_filename(&p.query);
+                let report = ContextGenerator::render_report(
+                    &index.db,
+                    &data,
+                    &files,
+                    Some(&p.query),
+                    &filename,
+                )
+                .map_err(internal)?;
+                Ok(Self::ok_with_warning(index.warning, report))
+            }
+        }
+    }
+
+    #[tool(
+        description = "Look up a symbol by exact name and return every definition in the index as a JSON array. Each match has: file, name, kind, line, signature, is_public, callers (symbols that call it, with their files), and callees (symbols it calls; each callee's file comes from the resolver and is null when the definition is ambiguous or unknown). When a name is defined in multiple files all matches are returned; pass `file` to restrict to one. Use this to jump to a definition or trace call relationships. Results come from the pre-built local amdb index created by `amdb init`."
+    )]
+    async fn amdb_get_symbol(
+        &self,
+        params: Parameters<GetSymbolParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let p = params.0;
+        let index = match self.open_index() {
+            Ok(i) => i,
+            Err(e) => return Ok(e),
+        };
+
+        let mut symbols = index
+            .db
+            .get_symbols_by_name(&p.name)
+            .map_err(|e| internal(e.into()))?;
+
+        if let Some(file) = &p.file {
+            symbols.retain(|(f, _)| f == file);
+        }
+
+        let mut matches = Vec::new();
+        for (file, sym) in symbols {
+            let callers: Vec<serde_json::Value> = index
+                .db
+                .get_callers_of(&p.name, &file)
+                .map_err(|e| internal(e.into()))?
+                .into_iter()
+                .map(|r| json!({ "name": r.name, "file": r.file }))
+                .collect();
+
+            let callees: Vec<serde_json::Value> = index
+                .db
+                .get_callees_of(&file, &sym.name)
+                .map_err(|e| internal(e.into()))?
+                .into_iter()
+                .map(|(name, callee_file)| json!({ "name": name, "file": callee_file }))
+                .collect();
+
+            matches.push(json!({
+                "file": file,
+                "name": sym.name,
+                "kind": sym.kind,
+                "line": sym.line,
+                "signature": sym.signature,
+                "is_public": sym.is_public,
+                "callers": callers,
+                "callees": callees,
+            }));
+        }
+
+        let payload = serde_json::to_string_pretty(&serde_json::Value::Array(matches))
+            .map_err(|e| internal(e.into()))?;
+
+        Ok(Self::ok_with_warning(index.warning, payload))
+    }
+}
+
+#[tool_handler(
+    name = "amdb",
+    version = "0.7.0",
+    instructions = "amdb serves a pre-built local index of this codebase (SQLite + embeddings, built by `amdb init`). Use amdb_get_context for a project overview, amdb_focus for context about one feature or file, and amdb_get_symbol to find definitions and call relationships. All data is local; nothing leaves the machine. If tools report a missing or stale index, ask the user to run `amdb init`."
+)]
+impl ServerHandler for AmdbServer {}
+
+pub async fn serve_stdio() -> anyhow::Result<()> {
+    let service = AmdbServer.serve(rmcp::transport::stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -230,7 +230,7 @@ impl AmdbServer {
 
 #[tool_handler(
     name = "amdb",
-    version = "0.7.0",
+    version = "0.8.0",
     instructions = "amdb serves a pre-built local index of this codebase (SQLite + embeddings, built by `amdb init`). Use amdb_get_context for a project overview, amdb_focus for context about one feature or file, and amdb_get_symbol to find definitions and call relationships. All data is local; nothing leaves the machine. If tools report a missing or stale index, ask the user to run `amdb init`."
 )]
 impl ServerHandler for AmdbServer {}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8,6 +8,107 @@ fn open_context_db(root: &std::path::Path) -> Connection {
     Connection::open(root.join(".database/context.db")).expect("open context.db")
 }
 
+struct McpClient {
+    child: std::process::Child,
+    stdin: std::process::ChildStdin,
+    rx: std::sync::mpsc::Receiver<String>,
+    next_id: i64,
+}
+
+impl McpClient {
+    fn start(dir: &std::path::Path) -> Self {
+        let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_amdb"))
+            .current_dir(dir)
+            .arg("serve")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn amdb serve");
+
+        let stdin = child.stdin.take().expect("child stdin");
+        let stdout = child.stdout.take().expect("child stdout");
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        std::thread::spawn(move || {
+            use std::io::BufRead;
+            let reader = std::io::BufReader::new(stdout);
+            for line in reader.lines().map_while(Result::ok) {
+                if tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            child,
+            stdin,
+            rx,
+            next_id: 1,
+        }
+    }
+
+    fn send(&mut self, value: serde_json::Value) {
+        use std::io::Write;
+        let mut line = value.to_string();
+        line.push('\n');
+        self.stdin.write_all(line.as_bytes()).expect("write stdin");
+        self.stdin.flush().expect("flush stdin");
+    }
+
+    fn request(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.send(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }));
+
+        loop {
+            let line = self
+                .rx
+                .recv_timeout(std::time::Duration::from_secs(120))
+                .expect("mcp response before timeout");
+            let msg: serde_json::Value = serde_json::from_str(&line).expect("valid jsonrpc line");
+            if msg.get("id").and_then(|v| v.as_i64()) == Some(id) {
+                return msg;
+            }
+        }
+    }
+
+    fn initialize(&mut self) -> serde_json::Value {
+        let resp = self.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "amdb-test-client", "version": "0.0.0"},
+            }),
+        );
+        self.send(serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        }));
+        resp
+    }
+
+    fn call_tool(&mut self, name: &str, arguments: serde_json::Value) -> serde_json::Value {
+        self.request(
+            "tools/call",
+            serde_json::json!({"name": name, "arguments": arguments}),
+        )
+    }
+}
+
+impl Drop for McpClient {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
 fn parse_mermaid_edges(content: &str) -> Vec<(String, String)> {
     content
         .lines()
@@ -894,4 +995,130 @@ fn test_ambiguous_callee_marked_unresolved_or_split() -> Result<(), Box<dyn std:
     }
 
     Ok(())
+}
+
+#[test]
+fn test_serve_starts_and_responds_to_initialize() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut client = McpClient::start(temp_dir.path());
+
+    let resp = client.initialize();
+    let result = &resp["result"];
+
+    assert!(result["protocolVersion"].is_string());
+    assert_eq!(result["serverInfo"]["name"], "amdb");
+    assert!(result["capabilities"]["tools"].is_object());
+}
+
+#[test]
+fn test_get_symbol_disambiguates_duplicate_names() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    fs::write(root.join("alpha_module.rs"), "fn shared_dup_fn() {}").unwrap();
+    fs::write(root.join("beta_module.rs"), "\n\nfn shared_dup_fn() {}").unwrap();
+
+    cargo_bin_cmd!("amdb")
+        .current_dir(root)
+        .arg("init")
+        .arg(".")
+        .assert()
+        .success();
+
+    let mut client = McpClient::start(root);
+    client.initialize();
+
+    let resp = client.call_tool(
+        "amdb_get_symbol",
+        serde_json::json!({"name": "shared_dup_fn"}),
+    );
+    let result = &resp["result"];
+    assert_ne!(result["isError"], true);
+
+    let text = result["content"][0]["text"].as_str().expect("text content");
+    let matches: serde_json::Value = serde_json::from_str(text).expect("json payload");
+    let arr = matches.as_array().expect("array of matches");
+
+    assert_eq!(arr.len(), 2);
+
+    let mut by_file: std::collections::HashMap<&str, i64> = std::collections::HashMap::new();
+    for m in arr {
+        by_file.insert(
+            m["file"].as_str().expect("file"),
+            m["line"].as_i64().expect("line"),
+        );
+    }
+
+    assert_eq!(by_file.len(), 2);
+    assert_eq!(by_file["alpha_module.rs"], 1);
+    assert_eq!(by_file["beta_module.rs"], 3);
+}
+
+#[test]
+fn test_get_symbol_returns_callee_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    fs::write(root.join("definer_module.rs"), "fn unique_target_fn() {}").unwrap();
+    fs::write(
+        root.join("caller_module.rs"),
+        "fn unique_caller_fn() { unique_target_fn(); }",
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("amdb")
+        .current_dir(root)
+        .arg("init")
+        .arg(".")
+        .assert()
+        .success();
+
+    let mut client = McpClient::start(root);
+    client.initialize();
+
+    let resp = client.call_tool(
+        "amdb_get_symbol",
+        serde_json::json!({"name": "unique_caller_fn"}),
+    );
+    let result = &resp["result"];
+    assert_ne!(result["isError"], true);
+
+    let text = result["content"][0]["text"].as_str().expect("text content");
+    let matches: serde_json::Value = serde_json::from_str(text).expect("json payload");
+    let arr = matches.as_array().expect("array of matches");
+
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["file"], "caller_module.rs");
+
+    let callees = arr[0]["callees"].as_array().expect("callees array");
+    assert_eq!(callees.len(), 1);
+    assert_eq!(callees[0]["name"], "unique_target_fn");
+    assert_eq!(callees[0]["file"], "definer_module.rs");
+}
+
+#[test]
+fn test_tools_error_without_index() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut client = McpClient::start(temp_dir.path());
+    client.initialize();
+
+    let calls = [
+        ("amdb_get_context", serde_json::json!({})),
+        ("amdb_focus", serde_json::json!({"query": "anything"})),
+        ("amdb_get_symbol", serde_json::json!({"name": "anything"})),
+    ];
+
+    for (tool, args) in calls {
+        let resp = client.call_tool(tool, args);
+        let result = &resp["result"];
+        assert_eq!(result["isError"], true, "tool {} should error", tool);
+
+        let text = result["content"][0]["text"].as_str().expect("text content");
+        assert!(
+            text.contains("amdb init"),
+            "tool {} error should mention amdb init, got: {}",
+            tool,
+            text
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- New `amdb serve` subcommand: a stdio-only MCP server (`src/mcp.rs`) built on the official Rust SDK **rmcp 2.2.0** (`server, macros, transport-io, schemars`). Local-first: no HTTP, no remote hosting. Targets MCP 2025-11-25, negotiates down to 2024-11-05.
- Three tools, all reading the pre-built SQLite index (never indexing on demand):
  - `amdb_get_context` — full project overview (file/symbol summaries + mermaid dependency graph), same content as `generate`.
  - `amdb_focus` — query-narrowed context via exact name match, then vector search with graph boosting, expanded by `depth` hops.
  - `amdb_get_symbol` — every definition of a name as JSON: file, kind, line, signature, is_public, callers, callees (callee file from the #49 resolver output; null when unresolved).
- DB path comes from `Config::db_dir` / `vector_dir` (#55) — no independent derivation. Missing index → tool-level error naming `amdb init`; stale schema (`needs_reindex`) → explicit warning block, never silent stale data.
- `serve` logs to stderr so stdout stays a clean JSON-RPC channel; errors route through the unified #51 exit path.
- Generator refactored for reuse (`load_graph_data` / `compute_focus_files` / `render_report`); `resolve_focus_targets` de-asynced (it never awaited, and holding `&ContextDb` across an await made the tool future `!Send`).
- Added `.vscode/mcp.json` (narrowed the `.gitignore` rule that ignored all of `.vscode`) and a README "MCP Server" section with VSCode/Cursor/Claude Code config.

## Verified against a real client
Claude Code: `claude mcp add amdb -- amdb serve` → `claude mcp list` reports `✔ Connected`, and a live session invoked `amdb_get_symbol` through the server, returning correct caller/callee JSON.

## Deviations from the issue spec (stated)
- `amdb_get_context.depth` accepted but inert — the CLI's full `generate` also ignores depth without `--focus`; documented in the schema.
- `callers[]` element shape was unspecified; used `{name, file}`, symmetric with `callees[]`. Unresolved callers (NULL `callee_file`) appear on every duplicate match rather than being dropped.
- On no match `amdb_focus` returns a "no files matched" message instead of the CLI's fall-back-to-full-context, so an LLM asking for narrow context never silently receives the whole project. `amdb_get_symbol` returns `[]` for unknown names.
- rmcp's documented server-name default (`CARGO_CRATE_NAME`) actually resolves to `"rmcp"`; name/version set explicitly.

## Tests
- `test_serve_starts_and_responds_to_initialize`, `test_get_symbol_disambiguates_duplicate_names`, `test_get_symbol_returns_callee_file`, `test_tools_error_without_index` — driven over stdio by a minimal JSON-RPC client written in the test file (no new test dependencies beyond `serde_json`).
- All 36 tests green (7 unit + 29 integration); `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt` clean.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)